### PR TITLE
fix: export `NotificationKind` as `enum` over `type`

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,9 +1,11 @@
 export { default as NotificationList } from '$lib/components/NotificationList.svelte';
-export { default as notifications } from '$lib/stores/notifications';
+export {
+  default as notifications,
+  NotificationKind
+} from '$lib/stores/notifications';
 
 export type {
   Notification,
   NotificationStoreMethods,
-  NotificationStore,
-  NotificationKind
+  NotificationStore
 } from '$lib/stores/notifications';

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -15,9 +15,9 @@ export type NotificationStore = {
 };
 
 export enum NotificationKind {
-  Failure,
-  Success,
-  Warning
+  Failure = 'Failure',
+  Success = 'Success',
+  Warning = 'Warning'
 }
 
 export type Notification = {


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
